### PR TITLE
Rectif. de la couleur de Font sur fond jaune / vert

### DIFF
--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -893,7 +893,7 @@ class vigilancemeteo extends eqLogic {
                 }
                     if ($cmd->getLogicalId() == 'general') {
                         $replace['#' . $cmd->getLogicalId() . '_color#'] = $color;
-                        if ($replace['#general_color#'] == "yellow" || $replace['#general_color#'] == "green") {
+                        if ($replace['#general_color#'] == "yellow" || $replace['#general_color#'] == "lime") {
                             $replace['#general_font#'] = "black";
                         } else {
                             $replace['#general_font#'] = "white";


### PR DESCRIPTION
Le texte noir doit être affiché si fond Yellow et Lime (et non Green).