### PR TITLE
Ré-écriture du type 'pluie1h' + ajout commande "minute avant pluie"

### DIFF
--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -789,17 +789,22 @@ class vigilancemeteo extends eqLogic {
             $this->checkAndUpdateCmd('lastUpdate', $prevPluieData['lastUpdate']);
 
             # compute the rain summary for the next hour
+            $minutesAvantPluie = null;
             $pluieDanslHeureCount = 0;
             for($i=0; $i <= 11; $i++) {
                 $cmdName = sprintf('prev%d', $i * 5);
                 $prevCmd = $this->getCmd(null, $cmdName);
                 if(is_object($prevCmd)){
                     //log::add('previsionpluie', 'debug', 'prev' . $i*5 . ': ' . $prevPluieData['dataCadran'][$i]['niveauPluie']);
-                    $this->checkAndUpdateCmd($cmdName, $prevPluieData['dataCadran'][$i]['niveauPluie']);
-                    $pluieDanslHeureCount = $pluieDanslHeureCount + $prevPluieData['dataCadran'][$i]['niveauPluie'];
+                    $niveau = intval($prevPluieData['dataCadran'][$i]['niveauPluie']);
+                    $this->checkAndUpdateCmd($cmdName, $niveau);
+                    $pluieDanslHeureCount += $niveau;
+                    if ($niveau > 1 && is_null($minutesAvantPluie)) {
+                        $minutesAvantPluie = $i * 5;
+                    }
                 }
             }
-
+            $this->checkAndUpdateCmd('minutesAvantPluie', $minutesAvantPluie);
             $this->checkAndUpdateCmd('pluieDanslHeure', $pluieDanslHeureCount);
             log::add('vigilancemeteo', 'info', sprintf("%s '%s' %s '%s'",
                                                     __('VigilanceMeteo de type', __FILE__),

--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -76,7 +76,7 @@ class vigilancemeteo extends eqLogic {
         log::add('vigilancemeteo', 'debug', 'Hourly cron');
     }
 
-    public static function cronDaily() {
+    /*public static function cronDaily() {
         foreach (eqLogic::byType('vigilancemeteo', true) as $vigilancemeteo) {
             foreach ($vigilancemeteo->getCmd() as $cmd) {
                 $cmd->setConfiguration('alert', '0');
@@ -84,7 +84,7 @@ class vigilancemeteo extends eqLogic {
                 $cmd->save();
             }
         }
-    }
+    }*/
 
     public function loadCmdFromConf($_update = false) {
 

--- a/core/config/devices/pluie1h.json
+++ b/core/config/devices/pluie1h.json
@@ -1,9 +1,9 @@
 {
     "name": "Pluie 1h",
-	"configuration" : {
-		"model" : "pluie1h",
+    "configuration" : {
+        "model" : "pluie1h",
         "type" : "pluie1h"
-	},
+    },
     "commands": [
         {
             "name": "Previsions Textuelles",

--- a/core/config/devices/pluie1h.json
+++ b/core/config/devices/pluie1h.json
@@ -22,6 +22,12 @@
             "type": "info",
             "subtype": "numeric",
             "logicalId": "pluieDanslHeure"
+        },
+        {
+            "name": "Delai avant prochaine pluie",
+            "type": "info",
+            "subtype": "numeric",
+            "logicalId": "minutesAvantPluie"
         }
     ]
 }


### PR DESCRIPTION
Bonjour

J'ai ajouté une commande "minutes avant pluie" dans les équipements de type "pluie à 1 heure".
L'idée et d'avoir l'heure de début de pluie directement accessible dans un scénario sans avoir à tester les 12 commandes des 12 créneaux de 5 minutes. Ainsi on peut être notifié de rentrer le linge, fermer le Velux, prendre le parapluie, ....

Les premier commits contiennent une refactorisation de l'indentation. J'ai également pris la liberté de ré-écrire la fonction de pooling de la pluie 'getPluie()'.
Je l'ai rendu un peu plus lisible notamment en limitant la répétition du code qui intérroge l'url.
J'ai également amélioré le log en utilisant d'avantage les niveau warning, error et info.

Les modifications tournent depuis 3 jours sans soucis chez moi.