### PR TITLE
Change user templates names

### DIFF
--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -1379,8 +1379,8 @@ public function getPollen() {
       }
       $templatename = 'previsionpluie';
     }
-    if (file_exists( __DIR__ ."/../template/$_version/".$templatename."_user.html")) {
-      return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, $templatename."_user", __CLASS__)));
+    if (file_exists( __DIR__ .'/../template/'.$_version.'/custom.'.$templatename.'.html')) {
+      return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, 'current.'.$templatename, __CLASS__)));
     }
     else {
       return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, $templatename, __CLASS__)));

--- a/plugin_info/pre_install.php
+++ b/plugin_info/pre_install.php
@@ -1,0 +1,30 @@
+<?php
+
+/* This file is part of Jeedom.
+ *
+ * Jeedom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jeedom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once __DIR__ . '/../../../core/php/core.inc.php';
+
+function vigilancemeteo_pre_update() {
+  $srcDir	 = __DIR__ . '/../core/template/dashboard/';
+  $files = array('air','crue','gdacs','maree','plage','pollen','previsionpluie','surf','uvi','vigilancemeteo');
+  foreach($files as $file) {
+    if (file_exists($srcDir .$file .'_user.html')) {
+      shell_exec('cp '.$srcDir .$file .'_user.html ' .$srcDir .'custom.' .$file .'.html');
+    }
+  }
+}
+?>


### PR DESCRIPTION
Copie si elle existe de l'ancienne template utilisateur dans un nom où elle ne sera pas supprimée par une mise à jour du plugin. (à partir de Jeedom 4.0.56)
Modif de la classe pour utilisation du fichier avec le nouveau nom.

Y a-t-il encore un pilote dans l'avion chez Jeedom ?
Modification en cours de version impactant le fonctionnement des plugins. Pas de communication et pas de réponse officielle aux questions posées sur Community.
Exemple pour du nettoyage fait par une MAJ du plugin cloudsyncpro:
Avant MAJ plugin fonctionnel 7226 fichiers.
Aprés MAJ il reste 5337 fichiers. Toute la partie api php Google  a sauté. Il faut relancer les dépendances pour les reinstaller.