### PR TITLE
Correct Crue Débit

### DIFF
--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -1261,11 +1261,11 @@ public function getPollen() {
               $datedebit = $date;
             }
           }
-          $hitsory = '';
+          $history = '';
           if ($cmddeb->getIsHistorized() == 1) {
-            $hitsory = 'history cursor';
+            $history = 'history cursor';
           }
-          $replace['#debit#'] = '<span style="margin-left: 30px;" class="debit ' . $hitsory . ' data-cmd_id="' . $cmd->getId() . '" title="Débit mesuré le ' . $datedebit . ' (' . $cmd->getCollectDate() . ')">D=' . $cmd->execCmd() . 'm3/s</span>';
+          $replace['#debit#'] = '<span style="margin-left: 30px;" class="debit ' . $history . '" data-cmd_id="' . $cmd->getId() . '" title="Débit mesuré le ' . $datedebit . ' (' . $cmd->getCollectDate() . ')">D=' . $cmd->execCmd() / 1000 . ' m3/s</span>';
         }
       }
       $templatename = 'crue';


### PR DESCRIPTION
Salut ;-) 

Suite à l'installation, voici un 1er PR pour le widget Crue (Débit) 
- une correction de typo de variable
- l'ajout d'un guillemet manquant
- l'ajout d'un espace entre l'unité et la valeur dans le widget.
mais surtout : 
- une division par 1000 de la valeur affiché. Car dans le flux XML ( https://www.vigicrues.gouv.fr/services/observations.xml/?CdStationHydro=X045401001 ) les valeurs sont en LITRES, et là le widget les affiches en M3. 

Qu'en penses tu ?