### PR TITLE
Ajout Cupressacées et message si nouveau pollen

### DIFF
--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -805,6 +805,7 @@ public function getPollen() {
       $nomPollen = $pollen['pollenName']; $level = $pollen['level'];
       switch ( $nomPollen ) {
         case "Cyprès" :
+	case "Cupressacées" :
           $this->checkAndUpdateCmd('pollen1', $level); break;
         case "Noisetier" :
           $this->checkAndUpdateCmd('pollen2', $level); break;
@@ -842,6 +843,8 @@ public function getPollen() {
           $this->checkAndUpdateCmd('pollen18', $level); break;
         case "Ambroisies" :
           $this->checkAndUpdateCmd('pollen19', $level); break;
+	default:
+          message::add(__CLASS__ .'-' .__FUNCTION__, "Pollen non traité: $nomPollen");
       }
     }
   }


### PR DESCRIPTION
Ajout du pollen Cupressacées qui semble avoir remplacé Cyprès dans le json.
Ajout d'un message Pollen non traité si un pollen est renommé ou si un nouveau est ajouté