### PR TITLE
Corrections pour v4 et les marées

### DIFF
--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -511,6 +511,7 @@ public function getMaree($_clean=0) {
 
   // fichier cache retour de MeteoConsult
   $JsonFile = jeedom::getTmpFolder(__CLASS__) ."/" .__CLASS__."-" .$this->getId() .".json";
+  if($_clean == 1) @unlink($JsonFile); // Avec nettoyage ancien fichier ex: Chgt de port
   if(!file_exists($JsonFile)) {
     $url = "http://webservices.meteoconsult.fr/meteoconsultmarine/androidtab/115/fr/v20/previsionsSpot.php?lat=$lat&lon=$lon";
     log::add(__CLASS__, 'error', "Retreiving data from: $url");
@@ -546,6 +547,12 @@ public function getMaree($_clean=0) {
       }
       if($datetimeTSnext == 0 && $datetimeTS > $now) {
         $datetimeTSnext = $datetimeTS;
+        if(isset($dec['contenu']['marees'][$i]['lieu'])) {
+          $harbor = $dec['contenu']['marees'][$i]['lieu'];
+          $pos = strpos($harbor,'© SHOM'); // suppression de: Heures locales
+          if($pos !== false) $harborName = trim(substr($harbor,0,$pos+7));
+          else $harborName = trim($harbor);
+        }
         break;
       }
     }

--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -52,6 +52,7 @@ class vigilancemeteo extends eqLogic {
   }
 
   public static function cronHourly() {
+      $dat = date('G');
     foreach (eqLogic::byType(__CLASS__, true) as $vigilancemeteo) {
       if ($vigilancemeteo->getConfiguration('type') == 'air') {
         $vigilancemeteo->getAir();
@@ -62,7 +63,7 @@ class vigilancemeteo extends eqLogic {
       else if ($vigilancemeteo->getConfiguration('type') == 'surf') {
         $vigilancemeteo->getSurf();
       }
-      else if ($vigilancemeteo->getConfiguration('type') == 'pollen') {
+        else if ($vigilancemeteo->getConfiguration('type') == 'pollen'&& $dat > 7 && $dat < 20) {
         $vigilancemeteo->getPollen();
       }
       else if ($vigilancemeteo->getConfiguration('type') == 'plage') {
@@ -294,48 +295,24 @@ public function getVigilance() {
       }
       foreach($data->getElementsByTagName('risque') as $risque) {
         switch ($risque->getAttribute('valeur')) {
-          case 1:
-          $lrisque[] = "vent";
-          break;
-          case 2:
-          $lrisque[] = "pluie-inondation";
-          break;
-          case 3:
-          $lrisque[] = "orages";
-          break;
-          case 4:
-          $lrisque[] = "inondations";
-          break;
-          case 5:
-          $lrisque[] = "neige-verglas";
-          break;
-          case 6:
-          $lrisque[] = "canicule";
-          break;
-          case 7:
-          $lrisque[] = "grand-froid";
-          break;
+          case 1: $lrisque[] = "vent"; break;
+          case 2: $lrisque[] = "pluie-inondation"; break;
+          case 3: $lrisque[] = "orages"; break;
+          case 4: $lrisque[] = "inondations"; break;
+          case 5: $lrisque[] = "neige-verglas"; break;
+          case 6: $lrisque[] = "canicule"; break;
+          case 7: $lrisque[] = "grand-froid"; break;
         }
       }
     }
     if ($data->getAttribute('dep') == $departement.'10') {
       //alerte mer
       switch ($data->getAttribute('couleur')) {
-        case 0:
-        $lmer = "vert";
-        break;
-        case 1:
-        $lmer = "vert";
-        break;
-        case 2:
-        $lmer = "jaune";
-        break;
-        case 3:
-        $lmer = "orange";
-        break;
-        case 4:
-        $lmer = "rouge";
-        break;
+        case 0: $lmer = "vert"; break;
+        case 1: $lmer = "vert"; break;
+        case 2: $lmer = "jaune"; break;
+        case 3: $lmer = "orange"; break;
+        case 4: $lmer = "rouge"; break;
       }
 
     }
@@ -353,68 +330,41 @@ public function getVigilance() {
       foreach($data->getElementsByTagName('risque') as $risque) {
         switch ($risque->getAttribute('val')) {
           case 1:
-          if ($lrisque == "RAS") {
-            $lrisque = "vent ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", vent ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "vent ".$couleur;
+            else $lrisque = $lrisque . ", vent ".$couleur;
+            break;
           case 2:
-          if ($lrisque == "RAS") {
-            $lrisque = "pluie-inondation ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", pluie-inondation ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "pluie-inondation ".$couleur;
+            else $lrisque = $lrisque . ", pluie-inondation ".$couleur;
+            break;
           case 3:
-          if ($lrisque == "RAS") {
-            $lrisque = "orages ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", orages ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "orages ".$couleur;
+            else $lrisque = $lrisque . ", orages ".$couleur;
+            break;
           case 4:
-          if ($lrisque == "RAS") {
-            $lrisque = "inondations ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", inondations ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "inondations ".$couleur;
+            else $lrisque = $lrisque . ", inondations ".$couleur;
+            break;
           case 5:
-          if ($lrisque == "RAS") {
-            $lrisque = "neige-verglas ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", neige-verglas ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "neige-verglas ".$couleur;
+            else $lrisque = $lrisque . ", neige-verglas ".$couleur;
+            break;
           case 6:
-          if ($lrisque == "RAS") {
-            $lrisque = "canicule ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", canicule ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "canicule ".$couleur;
+            else $lrisque = $lrisque . ", canicule ".$couleur;
+            break;
           case 7:
-          if ($lrisque == "RAS") {
-            $lrisque = "grand-froid ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", grand-froid ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "grand-froid ".$couleur;
+            else $lrisque = $lrisque . ", grand-froid ".$couleur;
+            break;
           case 8:
-          if ($lrisque == "RAS") {
-            $lrisque = "avalanches ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", avalanches ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "avalanches ".$couleur;
+            else $lrisque = $lrisque . ", avalanches ".$couleur;
+            break;
           case 9:
-          if ($lrisque == "RAS") {
-            $lrisque = "vagues-submersion ".$couleur;
-          } else {
-            $lrisque = $lrisque . ", vagues-submersion ".$couleur;
-          }
-          break;
+            if ($lrisque == "RAS") $lrisque = "vagues-submersion ".$couleur;
+            else $lrisque = $lrisque . ", vagues-submersion ".$couleur;
+            break;
         }
       }
     }
@@ -428,7 +378,6 @@ public function getVigilance() {
   $this->checkAndUpdateCmd('crue', $lcrue);
   $this->checkAndUpdateCmd('risque', $lrisque);
   $this->checkAndUpdateCmd('mer', $lmer);
-  return ;
 }
 
   public function getGDACS() {
@@ -560,7 +509,8 @@ public function getMaree($_clean=0) {
   }
   log::add(__CLASS__, 'debug', "Port: $port Name $harborName");
 
-  $JsonFile = jeedom::getTmpFolder(__CLASS__) ."/" .__CLASS__."-" .str_replace(' ','_',$harborName) .".json"; // fichier cache retour de MeteoConsult
+  // fichier cache retour de MeteoConsult
+  $JsonFile = jeedom::getTmpFolder(__CLASS__) ."/" .__CLASS__."-" .$this->getId() .".json";
   if(!file_exists($JsonFile)) {
     $url = "http://webservices.meteoconsult.fr/meteoconsultmarine/androidtab/115/fr/v20/previsionsSpot.php?lat=$lat&lon=$lon";
     log::add(__CLASS__, 'error', "Retreiving data from: $url");
@@ -922,6 +872,7 @@ public function getSurf() {
   }
   return ;
 }
+
 public function getPollen() {
     $geoloc = $this->getConfiguration('geoloc', 'none');
   if ($geoloc == 'none') {
@@ -1300,6 +1251,7 @@ public function getPollen() {
       $replace['#url_src#'] = "https://marine.meteoconsult.fr";
       $templatename = 'maree';
     }
+
     else if ($this->getConfiguration('type') == 'surf') {
       foreach ($this->getCmd('info') as $cmd) {
         $replace['#' . $cmd->getLogicalId() . '_history#'] = '';
@@ -1594,7 +1546,7 @@ public function getPollen() {
       $templatename = 'previsionpluie';
     }
     if (file_exists( __DIR__ ."/../template/$_version/custom.${templatename}.html")) {
-      return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, "custom.".$templatename, __CLASS__)));
+      return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, "custom." .$templatename, __CLASS__)));
     }
     else {
       return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, $templatename, __CLASS__)));

--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -1273,26 +1273,26 @@ public function getPollen() {
         }
       }
       $replace['#harborName#'] = '';
-      $cmd = jptyVigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'harborName');
+      $cmd = vigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'harborName');
       if(is_object($cmd)) $harborName = $cmd->execCmd();
       $replace['#harborName#'] = $harborName;
-      $cmd = jptyVigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'basse');
+      $cmd = vigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'basse');
       $txt = trim($cmd->execCmd());
       if(strlen($txt) == 3) $txt = '0'.$txt;
       $replace['#basse#'] = substr($txt,0,2) .':' .substr($txt,-2);
-      $cmd = jptyVigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'pleine');
+      $cmd = vigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'pleine');
       $txt = trim($cmd->execCmd());
       if(strlen($txt) == 3) $txt = '0'.$txt;
       $replace['#pleine#'] = substr($txt,0,2) .':' .substr($txt,-2);
-      $cmd = jptyVigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'maree');
+      $cmd = vigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'maree');
       $maree = $cmd->execCmd();
       self::tideColor($maree,$bgcolor,$txtcolor);
       $replace['#maree#'] = "<div class=\"tideGeneral\" style=\"background-color:$bgcolor; color:$txtcolor\"><center>$maree</center></div>";;
-      $cmd = jptyVigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'prevTide');
+      $cmd = vigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'prevTide');
       if(is_object($cmd)) $replace['#prevTide#'] = $cmd->execCmd();
-      $cmd = jptyVigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'nextTide');
+      $cmd = vigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'nextTide');
       if(is_object($cmd)) $replace['#nextTide#'] = $cmd->execCmd();
-      $cmd = jptyVigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'tidesTable');
+      $cmd = vigilancemeteoCmd::byEqLogicIdAndLogicalId($this->getId(),'tidesTable');
       if(is_object($cmd)) $replace['#tidesTable#'] = $cmd->execCmd();
       else $replace['#tidesTable#'] = 'Missing cmd tidesTable. Equipment should be resaved';
       $replace['#url_src#'] = "https://marine.meteoconsult.fr";

--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -22,11 +22,10 @@ class vigilancemeteo extends eqLogic {
 
   public static $_widgetPossibility = array('custom' => true);
 
-  public static function cron5() {
+  public static function cron() {
     foreach (eqLogic::byType(__CLASS__, true) as $vigilancemeteo) {
-      if ($vigilancemeteo->getConfiguration('type') == 'pluie1h') {
-        $vigilancemeteo->getPluie();
-        $vigilancemeteo->refreshWidget();
+      if ($vigilancemeteo->getConfiguration('type') == 'maree') {
+        if($vigilancemeteo->getMaree() != 0) $vigilancemeteo->refreshWidget();
       }
     }
   }

--- a/core/class/vigilancemeteo.class.php
+++ b/core/class/vigilancemeteo.class.php
@@ -25,7 +25,7 @@ class vigilancemeteo extends eqLogic {
   public static function cron() {
     foreach (eqLogic::byType(__CLASS__, true) as $vigilancemeteo) {
       if ($vigilancemeteo->getConfiguration('type') == 'maree') {
-        if($vigilancemeteo->getMaree() != 0) $vigilancemeteo->refreshWidget();
+        if($vigilancemeteo->getMaree(0) != 0) $vigilancemeteo->refreshWidget();
       }
     }
   }
@@ -35,7 +35,7 @@ class vigilancemeteo extends eqLogic {
       if ($vigilancemeteo->getConfiguration('type') == 'vigilance') {
         $vigilancemeteo->getVigilance();
       }
-      if ($vigilancemeteo->getConfiguration('type') == 'crue') {
+      else if ($vigilancemeteo->getConfiguration('type') == 'crue') {
         $vigilancemeteo->getCrue();
       }
       $vigilancemeteo->refreshWidget();
@@ -56,19 +56,19 @@ class vigilancemeteo extends eqLogic {
       if ($vigilancemeteo->getConfiguration('type') == 'air') {
         $vigilancemeteo->getAir();
       }
-      if ($vigilancemeteo->getConfiguration('type') == 'seisme') {
+      else if ($vigilancemeteo->getConfiguration('type') == 'seisme') {
         $vigilancemeteo->getSeisme();
       }
-      if ($vigilancemeteo->getConfiguration('type') == 'surf') {
+      else if ($vigilancemeteo->getConfiguration('type') == 'surf') {
         $vigilancemeteo->getSurf();
       }
-      if ($vigilancemeteo->getConfiguration('type') == 'pollen') {
+      else if ($vigilancemeteo->getConfiguration('type') == 'pollen') {
         $vigilancemeteo->getPollen();
       }
-      if ($vigilancemeteo->getConfiguration('type') == 'plage') {
+      else if ($vigilancemeteo->getConfiguration('type') == 'plage') {
         $vigilancemeteo->getPlage();
       }
-      if ($vigilancemeteo->getConfiguration('type') == 'gdacs') {
+      else if ($vigilancemeteo->getConfiguration('type') == 'gdacs') {
         $vigilancemeteo->getGDACS();
       }
       $vigilancemeteo->refreshWidget();
@@ -77,33 +77,33 @@ class vigilancemeteo extends eqLogic {
 
   public function getInformations() {
       if ($this->getConfiguration('type') == 'maree') {
-        $this->getMaree();
+        $this->getMaree(0);
       }
-      if ($this->getConfiguration('type') == 'air') {
+      else if ($this->getConfiguration('type') == 'air') {
         $this->getAir();
       }
-      if ($this->getConfiguration('type') == 'seisme') {
+      else if ($this->getConfiguration('type') == 'seisme') {
         $this->getSeisme();
       }
-      if ($this->getConfiguration('type') == 'surf') {
+      else if ($this->getConfiguration('type') == 'surf') {
         $this->getSurf();
       }
-      if ($this->getConfiguration('type') == 'pollen') {
+      else if ($this->getConfiguration('type') == 'pollen') {
         $this->getPollen();
       }
-      if ($this->getConfiguration('type') == 'plage') {
+      else if ($this->getConfiguration('type') == 'plage') {
         $this->getPlage();
       }
-      if ($this->getConfiguration('type') == 'pluie1h') {
+      else if ($this->getConfiguration('type') == 'pluie1h') {
         $this->getPluie();
       }
-      if ($this->getConfiguration('type') == 'vigilance') {
+      else if ($this->getConfiguration('type') == 'vigilance') {
         $this->getVigilance();
       }
-      if ($this->getConfiguration('type') == 'crue') {
+      else if ($this->getConfiguration('type') == 'crue') {
         $this->getCrue();
       }
-      if ($this->getConfiguration('type') == 'gdacs') {
+      else if ($this->getConfiguration('type') == 'gdacs') {
         $this->getGDACS();
       }
       $this->refreshWidget();
@@ -196,7 +196,7 @@ public function postUpdate() {
     $this->getVigilance();
   }
   if ($this->getConfiguration('type') == 'maree') {
-    $this->getMaree();
+    $this->getMaree(1);
   }
   if ($this->getConfiguration('type') == 'crue') {
     $this->getCrue();
@@ -525,6 +525,7 @@ public function emptyMaree($harborName,$_error='') {
 public function getMaree($_clean=0) {
   $t0 = microtime(true);
   $port = $this->getConfiguration('port');
+  log::add(__CLASS__, 'debug', "Port: $port Clean = $_clean");
   if ($port == '') {
     $this->emptyMaree('', "Marée : Port non saisi; Equipement: " .$this->getName());
     return(-1);
@@ -557,6 +558,7 @@ public function getMaree($_clean=0) {
     $this->emptyMaree('', "Harbor coordinate not found Port: $port");
     return(-1);
   }
+  log::add(__CLASS__, 'debug', "Port: $port Name $harborName");
 
   $JsonFile = jeedom::getTmpFolder(__CLASS__) ."/" .__CLASS__."-" .str_replace(' ','_',$harborName) .".json"; // fichier cache retour de MeteoConsult
   if(!file_exists($JsonFile)) {

--- a/core/config/PortsMareeInfo.json
+++ b/core/config/PortsMareeInfo.json
@@ -1,0 +1,284 @@
+[
+    { "id":70, "name":"Primel-Tregastel", "latitude":48.7133, "longitude":-3.825, "pays": "France", "CP": "29630"
+    },
+    { "id":136, "name":"Arcachon", "latitude":44.6633, "longitude":-1.15167, "pays": "France", "CP": "33120"
+    },
+    { "id":27, "name":"Arromanches", "latitude":49.3344, "longitude":-0.664167, "pays": "France", "CP": "14117"
+    },
+    { "id":71, "name":"Morlaix", "latitude":48.5883, "longitude":-3.83833, "pays": "France", "CP": "29600"
+    },
+    { "id":150, "name":"Baie de Somme (Le Crotoy)", "latitude":50.215, "longitude":1.63, "pays": "France", "CP": "80550"
+    },
+    { "id":137, "name":"Biscarrosse-Plage", "latitude":44.3594, "longitude":-1.27028, "pays": "France", "CP": "40600"
+    },
+    { "id":161, "name":"Bordeaux", "latitude":44.8617, "longitude":-0.55, "pays": "France", "CP": "33000"
+    },
+    { "id":140, "name":"Biarritz", "latitude":43.4408, "longitude":-1.59667, "pays": "France", "CP": "64200"
+    },
+    { "id":7, "name":"Boulogne-sur-Mer", "latitude":50.7317, "longitude":1.58667, "pays": "France", "CP": "62200"
+    },
+    { "id":5, "name":"Calais", "latitude":50.9717, "longitude":1.84, "pays": "France", "CP": "62100"
+    },
+    { "id":11, "name":"Cayeux-sur-Mer", "latitude":50.1667, "longitude":1.5, "pays": "France", "CP": "80410"
+    },
+    { "id":26, "name":"Courseulles", "latitude":49.3367, "longitude":-0.456667, "pays": "France", "CP": "14470"
+    },
+    { "id":14, "name":"Dieppe", "latitude":49.9367, "longitude":1.08167, "pays": "France", "CP": "76200"
+    },
+    { "id":24, "name":"Dives-sur-Mer", "latitude":49.2983, "longitude":-0.0883333, "pays": "France", "CP": "14160"
+    },
+    { "id":3, "name":"Dunkerque", "latitude":51.06, "longitude":2.35167, "pays": "France", "CP": "59140"
+    },
+    { "id":17, "name":"Etretat", "latitude":49.6972, "longitude":0.213889, "pays": "France", "CP": "76790"
+    },
+    { "id":16, "name":"Fecamp", "latitude":49.765, "longitude":0.363333, "pays": "France", "CP": "76400"
+    },
+    { "id":4, "name":"Gravelines", "latitude":51.0167, "longitude":2.09167, "pays": "France", "CP": "59820"
+    },
+    { "id":22, "name":"Honfleur", "latitude":49.4283, "longitude":0.231667, "pays": "France", "CP": "14600"
+    },
+    { "id":19, "name":"Le-Havre", "latitude":49.4867, "longitude":0.0916667, "pays": "France", "CP": "76600"
+    },
+    { "id":8, "name":"Le-Touquet", "latitude":50.5167, "longitude":1.56667, "pays": "France", "CP": "62520"
+    },
+    { "id":12, "name":"Le-Tréport", "latitude":50.065, "longitude":1.37, "pays": "France", "CP": "76470"
+    },
+    { "id":25, "name":"Ouistreham", "latitude":49.2888, "longitude":-0.24339, "pays": "France", "CP": "14121"
+    },
+    { "id":23, "name":"Deauville", "latitude":49.3717, "longitude":0.07, "pays": "France", "CP": "14800"
+    },
+    { "id":28, "name":"Port-en-Bessin", "latitude":49.3517, "longitude":-0.756667, "pays": "France", "CP": "14520"
+    },
+    { "id":29, "name":"Grandcamp-Maisy", "latitude":49.3917, "longitude":-1.04833, "pays": "France", "CP": "14450"
+    },
+    { "id":32, "name":"Barfleur", "latitude":49.67, "longitude":-1.26, "pays": "France", "CP": "50760"
+    },
+    { "id":33, "name":"Cherbourg", "latitude":49.6483, "longitude":-1.61833, "pays": "France", "CP": "50100"
+    },
+    { "id":35, "name":"Goury", "latitude":49.7154, "longitude":-1.94584, "pays": "France", "CP": "50440"
+    },
+    { "id":37, "name":"Diélette", "latitude":49.5533, "longitude":-1.86333, "pays": "France", "CP": "50340"
+    },
+    { "id":38, "name":"Barneville-Carteret", "latitude":49.3683, "longitude":-1.78833, "pays": "France", "CP": "50270"
+    },
+    { "id":39, "name":"Portbail", "latitude":49.3233, "longitude":-1.71667, "pays": "France", "CP": "50580"
+    },
+    { "id":45, "name":"Granville", "latitude":48.83, "longitude":-1.6, "pays": "France", "CP": "50400"
+    },
+    { "id":48, "name":"Cancale", "latitude":48.6667, "longitude":-1.98333, "pays": "France", "CP": "35260"
+    },
+    { "id":52, "name":"Saint-Malo", "latitude":48.64, "longitude":-2.02833, "pays": "France", "CP": "35400"
+    },
+    { "id":"55", "name":"Erquy", "latitude":48.6333, "longitude":-2.47667, "pays": "France", "CP": "22430"
+    },
+    { "id":"56", "name":"Pleneuf-Val-Andre-Dahouet", "latitude":48.58, "longitude":-2.57167, "pays": "France", "CP": "22370"
+    },
+    { "id":"57", "name":"Saint-Brieuc - Le Legué", "latitude":48.5367, "longitude":-2.715, "pays": "France", "CP": "22000"
+    },
+    { "id":"58", "name":"Binic", "latitude":48.6, "longitude":-2.81667, "pays": "France", "CP": "22520"
+    },
+    { "id":"60", "name":"Bréhat", "latitude":48.8342, "longitude":-2.9975, "pays": "France", "CP": "22870"
+    },
+    { "id":"62", "name":"Paimpol", "latitude":48.785, "longitude":-3.04167, "pays": "France", "CP": "22500"
+    },
+    { "id":"63", "name":"Lézardrieux", "latitude":48.7883, "longitude":-3.09833, "pays": "France", "CP": "22740"
+    },
+    { "id":"65", "name":"Tréguier", "latitude":48.7883, "longitude":-3.22167, "pays": "France", "CP": "22220"
+    },
+    { "id":"66", "name":"Perros-Guirec", "latitude":48.8033, "longitude":-3.43833, "pays": "France", "CP": "22700"
+    },
+    { "id":"67", "name":"Ploumanac'H", "latitude":48.835, "longitude":-3.48833, "pays": "France", "CP": "22700"
+    },
+    { "id":"68", "name":"Trébeurden", "latitude":48.7717, "longitude":-3.58333, "pays": "France", "CP": "22560"
+    },
+    { "id":"69", "name":"Locquirec", "latitude":48.69, "longitude":-3.64833, "pays": "France", "CP": "29241"
+    },
+    { "id":"72", "name":"Roscoff", "latitude":48.7133, "longitude":-3.965, "pays": "France", "CP": "29680"
+    },
+    { "id":"73", "name":"Brignogan-Plage", "latitude":48.6667, "longitude":-4.33333, "pays": "France", "CP": "29890"
+    },
+    { "id":"74", "name":"L'Aber-Wrac'h", "latitude":48.6, "longitude":-4.56167, "pays": "France", "CP": "29870"
+    },
+    { "id":"76", "name":"Portsall", "latitude":48.5633, "longitude":-4.715, "pays": "France", "CP": "29830"
+    },
+    { "id":"77", "name":"L'Aber-Ildut", "latitude":48.47, "longitude":-4.76167, "pays": "France", "CP": "29840"
+    },
+    { "id":"78", "name":"Ouessant", "latitude":48.455, "longitude":-5.09667, "pays": "France", "CP": "29242"
+    },
+    { "id":"80", "name":"Le-Conquet", "latitude":48.36, "longitude":-4.78333, "pays": "France", "CP": "29217"
+    },
+    { "id":"82", "name":"Brest", "latitude":48.3917, "longitude":-4.43, "pays": "France", "CP": "29200"
+    },
+    { "id":"83", "name":"Camaret-sur-Mer", "latitude":48.2783, "longitude":-4.58833, "pays": "France", "CP": "29570"
+    },
+    { "id":"84", "name":"Morgat", "latitude":48.2167, "longitude":-4.5, "pays": "France", "CP": "29160"
+    },
+    { "id":"85", "name":"Douarnenez", "latitude":48.1017, "longitude":-4.34, "pays": "France", "CP": "29100"
+    },
+    { "id":"86", "name":"Sein", "latitude":48.0372, "longitude":-4.8575, "pays": "France", "CP": "29990"
+    },
+    { "id":"87", "name":"Audierne", "latitude":48.0083, "longitude":-4.54, "pays": "France", "CP": "29770"
+    },
+    { "id":"88", "name":"Penmarc'H", "latitude":47.8014, "longitude":-4.33778, "pays": "France", "CP": "29760"
+    },
+    { "id":"288", "name":"Saint-Guenole", "latitude":47.7975, "longitude":-4.35861, "pays": "France", "CP": "29760"
+    },
+    { "id":"89", "name":"Guilvinec", "latitude":47.7914, "longitude":-4.28111, "pays": "France", "CP": "29730"
+    },
+    { "id":"90", "name":"Lesconil", "latitude":47.795, "longitude":-4.21, "pays": "France", "CP": "29740"
+    },
+    { "id":"91", "name":"Loctudy", "latitude":47.8367, "longitude":-4.17167, "pays": "France", "CP": "29750"
+    },
+    { "id":"92", "name":"Benodet", "latitude":47.8633, "longitude":-4.10833, "pays": "France", "CP": "29950"
+    },
+    { "id":"93", "name":"Concarneau", "latitude":47.8683, "longitude":-3.91333, "pays": "France", "CP": "29900"
+    },
+    { "id":"155", "name":"Port-Manech", "latitude":47.8017, "longitude":-3.73833, "pays": "France", "CP": "29920"
+    },
+    { "id":"151", "name":"Guidel-Plage-Le-Pouldu", "latitude":47.7717, "longitude":-3.52667, "pays": "France", "CP": "56520"
+    },
+    { "id":"95", "name":"Lorient", "latitude":47.7433, "longitude":-3.35, "pays": "France", "CP": "56100"
+    },
+    { "id":"97", "name":"Port-Louis", "latitude":47.7117, "longitude":-3.355, "pays": "France", "CP": "56290"
+    },
+    { "id":"98", "name":"Ile-de-Groix - Port-Tudy", "latitude":47.645, "longitude":-3.44667, "pays": "France", "CP": "56590"
+    },
+    { "id":"99", "name":"Etel", "latitude":47.66, "longitude":-3.20833, "pays": "France", "CP": "56410"
+    },
+    { "id":"100", "name":"Quiberon-Port-Maria", "latitude":47.4767, "longitude":-3.12333, "pays": "France", "CP": "56170"
+    },
+    { "id":"101", "name":"Belle-Ile-Le-Palais", "latitude":47.3467, "longitude":-3.15, "pays": "France", "CP": "56360"
+    },
+    { "id":"102", "name":"Quiberon-Port-Haliguen", "latitude":47.49, "longitude":-3.1, "pays": "France", "CP": "56170"
+    },
+    { "id":"105", "name":"Auray-Port de Saint-Goustan", "latitude":47.6633, "longitude":-2.97833, "pays": "France", "CP": "56400"
+    },
+    { "id":"154", "name":"Locmariaquer", "latitude":47.5333, "longitude":-2.87972, "pays": "France", "CP": "56740"
+    },
+    { "id":"106", "name":"Arradon", "latitude":47.615, "longitude":-2.82833, "pays": "France", "CP": "56610"
+    },
+    { "id":"107", "name":"Vannes", "latitude":47.6283, "longitude":-2.76167, "pays": "France", "CP": "56000"
+    },
+    { "id":"104", "name":"Port-Navalo", "latitude":47.55, "longitude":-2.91667, "pays": "France", "CP": "56640"
+    },
+    { "id":"156", "name":"Le Crouesty", "latitude":47.5417, "longitude":-2.90167, "pays": "France", "CP": "56640"
+    },
+    { "id":"112", "name":"Hoëdic", "latitude":47.3433, "longitude":-2.87333, "pays": "France", "CP": "56170"
+    },
+    { "id":"116", "name":"Pornichet", "latitude":47.2583, "longitude":-2.35167, "pays": "France", "CP": "44380"
+    },
+    { "id":"117", "name":"Saint-Nazaire-Saint-Brévin", "latitude":47.2733, "longitude":-1.885, "pays": "France", "CP": "44600"
+    },
+    { "id":"119", "name":"Pornic", "latitude":47.11, "longitude":-2.115, "pays": "France", "CP": "44210"
+    },
+    { "id":"120", "name":"L'Herbaudière", "latitude":47.0267, "longitude":-2.29667, "pays": "France", "CP": "85330"
+    },
+    { "id":"121", "name":"Fromentine", "latitude":46.8167, "longitude":-2.13333, "pays": "France", "CP": "85550"
+    },
+    { "id":"123", "name":"Ile-d'Yeu-Port Joinville", "latitude":46.7283, "longitude":-2.345, "pays": "France", "CP": "85350"
+    },
+    { "id":"126", "name":"Saint-Martin-en-Ré", "latitude":46.2083, "longitude":-1.365, "pays": "France", "CP": "17410"
+    },
+    { "id":"153", "name":"La Cotinière", "latitude":45.91, "longitude":-1.32833, "pays": "France", "CP": "17310"
+    },
+    { "id":"130", "name":"Cordouan", "latitude":45.5892, "longitude":-1.17369, "pays": "France", "CP": "17420"
+    },
+    { "id":"127", "name":"La-Rochelle", "latitude":46.155, "longitude":-1.15333, "pays": "France", "CP": "17000"
+    },
+    { "id":"103", "name":"La-Trinité-sur-Mer", "latitude":47.585, "longitude":-3.02333, "pays": "France", "CP": "56470"
+    },
+    { "id":"134", "name":"Lacanau", "latitude":44.9289, "longitude":-1.21444, "pays": "France", "CP": "33680"
+    },
+    { "id":"114", "name":"Le-Croisic", "latitude":47.3067, "longitude":-2.52333, "pays": "France", "CP": "44490"
+    },
+    { "id":"115", "name":"La-Baule-Le-Pouliguen", "latitude":47.2733, "longitude":-2.42333, "pays": "France", "CP": "44510"
+    },
+    { "id":"125", "name":"Les-Sables-d'Olonne", "latitude":46.4967, "longitude":-1.79667, "pays": "France", "CP": "85100"
+    },
+    { "id":"138", "name":"Mimizan-les-Bains", "latitude":44.2431, "longitude":-1.28694, "pays": "France", "CP": "40200"
+    },
+    { "id":"160", "name":"Pauillac", "latitude":45.1983, "longitude":-0.743333, "pays": "France", "CP": "33250"
+    },
+    { "id":"131", "name":"Royan", "latitude":45.62, "longitude":-1.025, "pays": "France", "CP": "17200"
+    },
+    { "id":"31", "name":"Saint-Vaast-la-Hougue", "latitude":49.5867, "longitude":-1.25833, "pays": "France", "CP": "50550"
+    },
+    { "id":"124", "name":"St-Gilles-Croix-de-Vie Port-la-Vie", "latitude":46.6917, "longitude":-1.95333, "pays": "France", "CP": "85800"
+    },
+    { "id":"54", "name":"Saint-Cast", "latitude":48.64, "longitude":-2.24333, "pays": "France", "CP": "22380"
+    },
+    { "id":"59", "name":"Saint-Quay-Portrieux", "latitude":48.6467, "longitude":-2.81667, "pays": "France", "CP": "22410"
+    },
+    { "id":"15", "name":"Saint-Valery-en-Caux", "latitude":49.8659, "longitude":0.710828, "pays": "France", "CP": "76460"
+    },
+    { "id":"159", "name":"Saint-Denis-d'Oléron", "latitude":46.035, "longitude":-1.36833, "pays": "France", "CP": "17650"
+    },
+    { "id":"141", "name":"Saint-Jean-de-Luz", "latitude":43.3967, "longitude":-1.67667, "pays": "France", "CP": "64500"
+    },
+    { "id":"139", "name":"Vieux Boucau - Port d'Albret Plage", "latitude":43.7558, "longitude":-1.41694, "pays": "France", "CP": "40480"
+    },
+    { "id":43, "name":"Coutainville", "latitudeHS":49.0017, "longitude":-1.58583, "pays": "France", "CP": "50230"
+    },
+    { "id":"133", "name":"Richards"
+    },
+    { "id":30, "name":"Iles Saint-Marcouf"
+    },
+    { "id":34, "name":"Omonville-la-Rogue"
+    },
+    { "id":40, "name":"Les Écréhou - L'Écrevière"
+    },
+    { "id":"6", "name":"Wissant"
+    },
+    { "id":42, "name":"Le Sénéquet"
+    },
+    { "id":47, "name":"Iles Chausey (Grande-Ile)"
+    },
+    { "id":"53", "name":"Ile des Hébihens"
+    },
+    { "id":"61", "name":"Les Héaux-de-Bréhat"
+    },
+    { "id":"64", "name":"Port-Béni"
+    },
+    { "id":"157", "name":"Locquemeau"
+    },
+    { "id":"75", "name":"L'Aber Benoît"
+    },
+    { "id":"79", "name":"Ile Molène"
+    },
+    { "id":"81", "name":"Trez-Hir"
+    },
+    { "id":"94", "name":"Penfret (Iles de Glénan)"
+    },
+    { "id":"96", "name":"Hennebont"
+    },
+    { "id":"110", "name":"Penerf"
+    },
+    { "id":"111", "name":"Tréhiguier"
+    },
+    { "id":"113", "name":"Houat"
+    },
+    { "id":"118", "name":"Pointe de Saint-Gildas"
+    },
+    { "id":"122", "name":"Fromentine Port"
+    },
+    { "id":"128", "name":"Ile d'Aix"
+    },
+    { "id":"135", "name":"Cap Ferret"
+    },
+    { "id":"162", "name":"Lamena", "latitudeHS": 45.33, "longitudeHS":-0.8
+    },
+    { "id":"109", "name":"Le Logeo"
+    },
+    { "id":"129", "name":"Pointe de Gatseau"
+    },
+    { "id":"132", "name":"Pointe de Grave (Port-Bloc)"
+    },
+    { "id":18, "name":"Le Havre-Antifer"
+    },
+    { "id":"108", "name":"Saint-Armel (Le Passage)"
+    },
+    { "id":"41", "name":"Saint-Germain-sur-Ay"
+    },
+    { "id":9, "name":"Berck Plage - Fort Mahon"
+    }
+]

--- a/core/config/devices/maree.json
+++ b/core/config/devices/maree.json
@@ -5,34 +5,52 @@
         "type" : "maree"
 	},
     "commands": [
-        {
-            "name": "Indicateur Marée",
+        { "name": "Indicateur Marée",
             "type": "info",
             "subtype": "numeric",
             "logicalId": "maree"
         },
-        {
-            "name": "Pleine Mer",
+        { "name": "Nom du port",
+            "type": "info",
+            "subtype": "string",
+            "logicalId": "harborName"
+        },
+        { "name": "Pleine Mer",
             "type": "info",
             "subtype": "numeric",
             "logicalId": "pleine"
         },
-        {
-            "name": "Basse Mer",
+        { "name": "Basse Mer",
             "type": "info",
             "subtype": "numeric",
             "logicalId": "basse"
         },
-        {
-            "name": "Rafraichir",
+        { "name": "Datetime prochaine marée",
+            "type": "info",
+            "subtype": "numeric",
+            "isVisible": 0,
+            "logicalId": "TSnextTide"
+        },
+        { "name": "Marée précédente",
+            "type": "info",
+            "subtype": "string",
+            "logicalId": "prevTide"
+        },
+        { "name": "Marée suivante",
+            "type": "info",
+            "subtype": "string",
+            "logicalId": "nextTide"
+        },
+        { "name": "Tableau des marées",
+            "type": "info",
+            "subtype": "string",
+            "logicalId": "tidesTable"
+        },
+        { "name": "Rafraichir",
             "type": "action",
             "subtype": "other",
-            "display": {
-      "icon": "<i class=\"fas fa-refresh\"><\/i>"
-            },
-            "configuration" : {
-          "request" : "refresh"
-        },
+            "display": { "icon": "<i class=\"fas fa-refresh\"><\/i>" },
+            "configuration" : { "request" : "refresh" },
             "isVisible": 1,
             "logicalId": "refresh"
         }

--- a/core/template/dashboard/maree.html
+++ b/core/template/dashboard/maree.html
@@ -1,37 +1,86 @@
-<div class="eqLogic-widget eqLogic allowResize" style="height: #height#;width: #width#;border:#border#;border-radius:#border-radius#;background-color: #background-color#;color: #color#;#style#" data-eqLogic_id="#id#" data-eqLogic_uid="#uid#" data-version="#version#" >
-	<center class="widget-name"><a href="#eqLink#" style="font-size : 1.5em;#hideEqLogicName#">#name_display#</a>
-<span class="pull-right cursor"><i id="yourvigilance#id#" class="fas fa-info-circle" style="color: var(--eqTitle-color) !important;"></i></span> &nbsp; <span class="cmd refresh pull-right cursor" data-cmd_id="#refresh#"><i class="fas fa-sync"></i></span>
-	</center><br />
-
-    <div class="row">
-
-	<div class="col-sm-12">
-	<center>
-	 <span class="basse #basse_history#" data-cmd_id="#basse_id#" title="Basse Mer (#basse_collect#)"><i class="wi wi-direction-down" style="font-size : 1.3em;"></i>  #basse#</span>
-	<span style="margin-left: 30px;" class="pleine #pleine_history#" data-cmd_id="#pleine_id#" title="Pleine Mer (#pleine_collect#)"><i class="wi wi-direction-up" style="font-size : 1.3em;"></i>  #pleine#</span>
-   </center>
-	</div>
-	</div>
-	<center>
-       <span class="risque #risque_history#" data-cmd_id="#maree_id#" title="Indice de Marée" style="font-size : 1.3em;">#maree#</span>
+<div class="eqLogic eqLogic-widget allowResize #custom_layout# #eqLogic_class# #class#" data-eqType="#eqType#" data-eqLogic_id="#id#" data-eqLogic_uid="#uid#" data-version="#version#" data-translate-category="#translate_category#" data-category="#category#" data-tags="#tags#" style="width: #width#;height: #height#;#style#">
+  <center class="widget-name">
+    <span class="warning" title="#alert_name#">
+      <i class='#alert_icon#'></i>
+    </span>
+    <span class="cmd pull-right cursor">
+      <a target="_blank" href="#url_src#" title="Plus d'info"><i class='fas fa-info-circle' style="margin-top: 3px;"></i></a>
+    </span>&nbsp;
+    <span class="cmd refresh pull-right cursor" data-cmd_id="#refresh_id#">
+      <i class="fas fa-sync"></i>
+    </span>
+    <span class="reportModeVisible">#name_display# <span class="object_name">#object_name#</span></span>
+    <a href="#eqLink#" class="reportModeHidden">#name_display# <span class="object_name">#object_name#</span></a>
+  </center>
+  <div class="row">
+    <center>
+      <span style="display: #basse_display#" class="basse #basse_history#" data-cmd_id="#basse_id#" title="Basse Mer (#basse_collect#)"><i class="wi wi-direction-down" style="font-size : 2em;"></i>  #basse#</span>
+      <span style="margin-left: 30px; display: #pleine_display#" class="pleine #pleine_history#" data-cmd_id="#pleine_id#" title="Pleine Mer (#pleine_collect#)"><i class="wi wi-direction-up" style="font-size : 2em;"></i>  #pleine#</span>
     </center>
-	<link rel="stylesheet" href="plugins/vigilancemeteo/desktop/weather-icons/css/weather-icons.css">
-
-<script>
-$('#yourvigilance#id#').on('click', function() {
-			$('#md_modal2').dialog({
-				title: "Vos Marées"
-			});
-
-			$('#md_modal2').load('index.php?v=d&plugin=vigilancemeteo&modal=vigilancemeteo&id=#id#').dialog('open');
-		});
-	
-			if ('#refresh#' != ''){
-			$('.eqLogic[data-eqLogic_uid=#uid#] .refresh').on('click', function () {
-				jeedom.cmd.execute({id: '#refresh#'});
-			});
-		}else{
-			$('.eqLogic[data-eqLogic_uid=#uid#] .refresh').remove();
-		}
-</script>
+  </div>
+    <div class="row">
+      <center>
+        <span class="risque #risque_history#" data-cmd_id="#risque_id#" title="Coefficient de Marée" style="text-decoration: none; cursor:default;font-size : 1.3em; display: #maree_display#">#maree#</span>
+      </center>
+    </div>
+    <div class="row">
+      <center>Port: <strong>#harborName#</strong></center>
+    </div>
+    <div class="row">
+      <center>
+        <span style="display: #prevTide_display#" class="prevTide #prevTide_history#" data-cmd_id="#prevTide_id#" title="Marée précédente (#prevTide_collect#)">#prevTide#</span>
+        <span style="margin-left: 10px; display: #nextTide_display#" class="nextTide #nextTide_history#" data-cmd_id="#nextTide_id#" title="Marée suivante"> #nextTide#</span>
+      </center>
+    </div>
+  <div class="row" style="margin-left: 5px; margin-right: 5px">
+     <span class="tidesTableCmd #tidesTable_history#" data-cmd_id="#tidesTable_id#" style="text-decoration: none; cursor:default; display: #tidesTable_display#">#tidesTable#</span>
+  </div>
+  <link rel="stylesheet" href="plugins/vigilancemeteo/desktop/weather-icons/css/weather-icons.css">
+  <style>
+    .tidesTableFactor {
+      display: table-cell;
+      border-style: solid;
+      border-width: 0px;
+      vertical-align: middle;
+      align: center;
+      border-radius: 12px;
+      width: 24px;
+      height: 24px;
+      cursor: default;
+      font-size: 0.8em;
+    }
+    .tideGeneral {
+      display: table-cell;
+      border-style: solid;
+      border-width: 0px;
+      vertical-align: middle;
+      align: center;
+      border-radius: 23px;
+      width: 46px;
+      height: 46px;
+      cursor: default;
+      font-size: 1.5em;
+      font-weight: bold;
+    }
+    .tidesTableCmd {
+      display: inline-block;
+      overflow-y:scroll;
+      border:#000000 1px solid;
+      width: 100%;
+      min-height:15px;
+      max-height: 240px;
+      word-wrap: break-word;
+      scrollbar-width: thin;
+      text-align: left
+    }
+  </style>
+  <script>
+    if ('#refresh_id#' != ''){
+      $('.eqLogic[data-eqLogic_uid=#uid#] .refresh').on('click', function () {
+        jeedom.cmd.execute({id: '#refresh_id#'});
+      });
+    }else{
+      $('.eqLogic[data-eqLogic_uid=#uid#] .refresh').remove();
+    }
+  </script>
 </div>

--- a/desktop/js/vigilancemeteo.js
+++ b/desktop/js/vigilancemeteo.js
@@ -164,6 +164,7 @@ $('#typeEq').change(function(){
 });
 
 function addCmdToTable(_cmd) {
+    var text = $("#typeEq").val();
     if (!isset(_cmd)) {
         var _cmd = {configuration: {}};
     }
@@ -176,10 +177,10 @@ function addCmdToTable(_cmd) {
       tr += '</td><td>';
       tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" style="width : 140px;" placeholder="{{Nom de la commande}}"></td>';
       tr += '</td><td>';
-      if (_cmd.subType == 'numeric' || _cmd.subType == 'binary') {
-        tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span>';
-        if ( typeof _cmd.configuration['logicalId'] != "undefined" && _cmd.configuration['logicalId'].substr(0,6) == 'pollen' ) {
-          tr += '<br/><span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" checked/>{{Afficher}}</label></span>';
+      if (_cmd.subType == 'numeric' || _cmd.subType == 'binary' || _cmd.subType == 'string') {
+        tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span> ';
+        if ( text == 'maree' || text == 'pollen'  || text == 'air') {
+          tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" checked/>{{Afficher}}</label></span> ';
         }
       }
       tr += '</td><td>';

--- a/desktop/js/vigilancemeteo.js
+++ b/desktop/js/vigilancemeteo.js
@@ -179,7 +179,7 @@ function addCmdToTable(_cmd) {
       tr += '</td><td>';
       if (_cmd.subType == 'numeric' || _cmd.subType == 'binary' || _cmd.subType == 'string') {
         tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span> ';
-        if ( text == 'maree' || text == 'pollen'  || text == 'air') {
+        if ( text == 'maree' || text == 'pollen'  || text == 'air' || text == 'crue') {
           tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" checked/>{{Afficher}}</label></span> ';
         }
       }

--- a/desktop/php/vigilancemeteo.php
+++ b/desktop/php/vigilancemeteo.php
@@ -143,18 +143,50 @@ $eqLogics = eqLogic::byType('vigilancemeteo');
                         </div>
 
                         <div id="portEq" class="form-group" style="display:none">
+              <div class="form-group">
                             <label class="col-sm-3 control-label">{{Port}}</label>
                             <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="port" placeholder="Ex 122"/>
+<?php
+                    $harbors = vigilancemeteo::mareeListHarbors();
+                    if($harbors !== null) {
+                      echo "<select type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\">";
+                      foreach($harbors as $harbor) {
+                        echo "<option value=" . $harbor['id'];
+                        if(!isset($harbor['latitude']) || !isset($harbor['longitude'])) {
+                          echo " disabled";
+                        }
+                        echo ">" .$harbor['name'] ." " .(isset($harbor['CP'])?$harbor['CP']:'---') ."</option>\n";
+                      }
+                      echo "</select>";
+                    }
+                    else {
+                      echo "<input type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\" placeholder=\"52 pour Saint-Malo voir le site maree.info\"/>";
+                    }
+?>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-3 control-label" ></label>
+                <div class="col-sm-3">
+                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useTideTemplate" checked/>{{Utiliser la template du plugin}}</label>
+                </div>
                             </div>
                         </div>
 
                         <div id="stationEq" class="form-group" style="display:none">
+              <div class="form-group">
                             <label class="col-sm-3 control-label">{{Station}}</label>
                             <div class="col-sm-3">
                                 <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="station" placeholder="Ex F700000103 pour Paris Austerlitz"/>
                             </div>
                         </div>
+              <div class="form-group">
+                <label class="col-sm-3 control-label" ></label>
+                <div class="col-sm-3">
+                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useFloodTemplate" checked/>{{Utiliser la template du plugin}}</label>
+                </div>
+              </div>
+            </div>
 
                         <div id="geolocEq" class="form-group" style="display:none">
                             <label class="col-sm-3 control-label">{{Localisation à utiliser}}</label>
@@ -224,18 +256,8 @@ $eqLogics = eqLogic::byType('vigilancemeteo');
                         </tr>
                     </thead>
                     <tbody>
-
                     </tbody>
                 </table>
-
-                <form class="form-horizontal">
-                    <fieldset>
-                        <div class="form-actions">
-                            <a class="btn btn-danger eqLogicAction" data-action="remove"><i class="fas fa-minus-circle"></i> {{Supprimer}}</a>
-                            <a class="btn btn-success eqLogicAction" data-action="save"><i class="fas fa-check-circle"></i> {{Sauvegarder}}</a>
-                        </div>
-                    </fieldset>
-                </form>
             </div>
         </div>
     </div>

--- a/desktop/php/vigilancemeteo.php
+++ b/desktop/php/vigilancemeteo.php
@@ -145,14 +145,14 @@ $eqLogics = eqLogic::byType('vigilancemeteo');
                         <div id="portEq" class="form-group" style="display:none">
                             <label class="col-sm-3 control-label">{{Port}}</label>
                             <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="port" placeholder="exemple 122"/>
+                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="port" placeholder="Ex 122"/>
                             </div>
                         </div>
 
                         <div id="stationEq" class="form-group" style="display:none">
                             <label class="col-sm-3 control-label">{{Station}}</label>
                             <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="station" placeholder="exemple 122"/>
+                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="station" placeholder="Ex F700000103 pour Paris Austerlitz"/>
                             </div>
                         </div>
 

--- a/desktop/php/vigilancemeteo.php
+++ b/desktop/php/vigilancemeteo.php
@@ -143,18 +143,50 @@ $eqLogics = eqLogic::byType('vigilancemeteo');
                         </div>
 
                         <div id="portEq" class="form-group" style="display:none">
+              <div class="form-group">
                             <label class="col-sm-3 control-label">{{Port}}</label>
                             <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="port" placeholder="exemple 122"/>
+<?php
+                    $harbors = vigilancemeteo::mareeListHarbors();
+                    if($harbors !== null) {
+                      echo "<select type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\">";
+                      foreach($harbors as $harbor) {
+                        echo "<option value=" . $harbor['id'];
+                        if(!isset($harbor['latitude']) || !isset($harbor['longitude'])) {
+                          echo " disabled";
+                        }
+                        echo ">" .$harbor['name'] ." " .(isset($harbor['CP'])?$harbor['CP']:'---') ."</option>\n";
+                      }
+                      echo "</select>";
+                    }
+                    else {
+                      echo "<input type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\" placeholder=\"52 pour Saint-Malo voir le site maree.info\"/>";
+                    }
+?>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-3 control-label" ></label>
+                <div class="col-sm-3">
+                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useTideTemplate" checked/>{{Utiliser la template du plugin}}</label>
+                </div>
                             </div>
                         </div>
 
                         <div id="stationEq" class="form-group" style="display:none">
+              <div class="form-group">
                             <label class="col-sm-3 control-label">{{Station}}</label>
                             <div class="col-sm-3">
                                 <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="station" placeholder="exemple 122"/>
                             </div>
                         </div>
+              <div class="form-group">
+                <label class="col-sm-3 control-label" ></label>
+                <div class="col-sm-3">
+                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useFloodTemplate" checked/>{{Utiliser la template du plugin}}</label>
+                </div>
+              </div>
+            </div>
 
                         <div id="geolocEq" class="form-group" style="display:none">
                             <label class="col-sm-3 control-label">{{Localisation à utiliser}}</label>

--- a/desktop/php/vigilancemeteo.php
+++ b/desktop/php/vigilancemeteo.php
@@ -94,10 +94,11 @@ $eqLogics = eqLogic::byType($plugin->getId());
                       <select id="sel_object" class="eqLogicAttr form-control" data-l1key="object_id">
                           <option value="">{{Aucun}}</option>
                           <?php
-										$options = '';
-										foreach ((jeeObject::buildTree(null, false)) as $object) {
-											$options .= '<option value="' . $object->getId() . '">' . str_repeat('&nbsp;&nbsp;', $object->getConfiguration('parentNumber')) . $object->getName() . '</option>';
+										      $options = '';
+										      foreach ((jeeObject::buildTree(null, false)) as $object) {
+											      $options .= '<option value="' . $object->getId() . '">' . str_repeat('&nbsp;&nbsp;', $object->getConfiguration('parentNumber')) . $object->getName() . '</option>';
                           }
+			                    echo $options;
                           ?>
                       </select>
                   </div>

--- a/desktop/php/vigilancemeteo.php
+++ b/desktop/php/vigilancemeteo.php
@@ -1,251 +1,267 @@
 <?php
-
 if (!isConnect('admin')) {
     throw new Exception('{{401 - Accès non autorisé}}');
 }
-sendVarToJS('eqType', 'vigilancemeteo');
-$eqLogics = eqLogic::byType('vigilancemeteo');
-
+// Déclaration des variables obligatoires
+$plugin = plugin::byId('vigilancemeteo');
+sendVarToJS('eqType', $plugin->getId());
+$eqLogics = eqLogic::byType($plugin->getId());
 ?>
 
 <div class="row row-overflow">
-  <div class="col-lg-2 col-sm-3 col-sm-4" id="hidCol" style="display: none;">
-    <div class="bs-sidebar">
-      <ul id="ul_eqLogic" class="nav nav-list bs-sidenav">
-        <li class="filter" style="margin-bottom: 5px;"><input class="filter form-control input-sm" placeholder="{{Rechercher}}" style="width: 100%"/></li>
-        <?php
-        foreach ($eqLogics as $eqLogic) {
-          echo '<li class="cursor li_eqLogic" data-eqLogic_id="' . $eqLogic->getId() . '"><a>' . $eqLogic->getHumanName(true) . '</a></li>';
-        }
-        ?>
-      </ul>
-    </div>
-  </div>
-
-  <div class="col-lg-12 eqLogicThumbnailDisplay" id="listCol">
+	<!-- Page d'accueil du plugin -->
+  <div class="col-xs-12 eqLogicThumbnailDisplay">
     <legend><i class="fas fa-cog"></i>  {{Gestion}}</legend>
-    <div class="eqLogicThumbnailContainer logoPrimary">
-
-      <div class="cursor eqLogicAction logoSecondary" data-action="add">
+		<!-- Boutons de gestion du plugin -->
+    <div class="eqLogicThumbnailContainer">
+      <div class="cursor eqLogicAction logoPrimary" data-action="add">
           <i class="fas fa-plus-circle"></i>
-          <br/>
+          <br>
         <span>{{Ajouter}}</span>
       </div>
       <div class="cursor eqLogicAction logoSecondary" data-action="gotoPluginConf">
         <i class="fas fa-wrench"></i>
-        <br/>
+        <br>
         <span>{{Configuration}}</span>
       </div>
-
     </div>
-
-    <input class="form-control" placeholder="{{Rechercher}}" id="in_searchEqlogic" />
-
-    <legend><i class="fas fa-home" id="butCol"></i> {{Mes Equipements}}</legend>
-    <div class="eqLogicThumbnailContainer">
+    <legend><i class="fas fa-table"></i> {{Mes Equipements}}</legend>
       <?php
+		if (count($eqLogics) == 0) {
+			echo '<br/><div class="text-center" style="font-size:1.2em;font-weight:bold;">{{Aucun équipement Template n\'est paramétré, cliquer sur "Ajouter" pour commencer}}</div>';
+		} else {
+			// Champ de recherche
+			echo '<div class="input-group" style="margin:5px;">';
+			echo '<input class="form-control roundedLeft" placeholder="{{Rechercher}}" id="in_searchEqlogic"/>';
+			echo '<div class="input-group-btn">';
+			echo '<a id="bt_resetSearch" class="btn" style="width:30px"><i class="fas fa-times"></i></a>';
+			echo '<a class="btn roundedRight hidden" id="bt_pluginDisplayAsTable" data-coreSupport="1" data-state="0"><i class="fas fa-grip-lines"></i></a>';
+			echo '</div>';
+			echo '</div>';
+			// Liste des équipements du plugin
+			echo '<div class="eqLogicThumbnailContainer">';
       foreach ($eqLogics as $eqLogic) {
-        $opacity = ($eqLogic->getIsEnable()) ? '' : jeedom::getConfiguration('eqLogic:style:noactive');
-        echo '<div class="eqLogicDisplayCard cursor" data-eqLogic_id="' . $eqLogic->getId() . '" style="background-color : #ffffff ; height : 200px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;' . $opacity . '" >';
-        echo "<center>";
-        echo '<img src="plugins/vigilancemeteo/plugin_info/vigilancemeteo_icon.png" height="105" width="95" />';
-        echo "</center>";
-        echo '<span style="font-size : 1.1em;position:relative; top : 15px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;"><center>' . $eqLogic->getHumanName(true, true) . '</center></span>';
+        $opacity = ($eqLogic->getIsEnable()) ? '' : 'disableCard';
+        echo '<div class="eqLogicDisplayCard cursor '.$opacity.'" data-eqLogic_id="' . $eqLogic->getId() . '">';
+        echo '<img src="' . $plugin->getPathImgIcon() . '"/>';
+        echo '<br>';
+        echo '<span class="name">' . $eqLogic->getHumanName(true, true) . '</span>';
+        echo '</div>';
+      }
         echo '</div>';
       }
       ?>
+	</div> <!-- /.eqLogicThumbnailDisplay -->
+
+	<!-- Page de présentation de l'équipement -->
+	<div class="col-xs-12 eqLogic" style="display: none;">
+		<!-- barre de gestion de l'équipement -->
+		<div class="input-group pull-right" style="display:inline-flex;">
+			<span class="input-group-btn">
+				<!-- Les balises <a></a> sont volontairement fermées à la ligne suivante pour éviter les espaces entre les boutons. Ne pas modifier -->
+        <a class="btn btn-sm btn-default eqLogicAction roundedLeft" data-action="configure"><i class="fas fa-cogs"></i><span class="hidden-xs"> {{Configuration avancée}}</span>
+				</a><a class="btn btn-sm btn-default eqLogicAction" data-action="copy"><i class="fas fa-copy"></i><span class="hidden-xs">  {{Dupliquer}}</span>
+        </a><a class="btn btn-sm btn-success eqLogicAction" data-action="save"><i class="fas fa-check-circle"></i> {{Sauvegarder}}
+        </a><a class="btn btn-sm btn-danger eqLogicAction roundedRight" data-action="remove"><i class="fas fa-minus-circle"></i> {{Supprimer}}
+        </a>
+			</span>
+    </div>
+		<!-- Onglets -->
+    <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fas fa-arrow-circle-left"></i></a></li>
+        <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
+        <li role="presentation"><a href="#commandtab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-list"></i> {{Commandes}}</a></li>
+    </ul>
+    <div class="tab-content">
+			<!-- Onglet de configuration de l'équipement -->
+      <div role="tabpanel" class="tab-pane active" id="eqlogictab">
+				<!-- Partie gauche de l'onglet "Equipements" -->
+				<!-- Paramètres généraux de l'équipement -->
+        <form class="form-horizontal">
+          <fieldset>
+						<div class="col-lg-6">
+							<legend><i class="fas fa-wrench"></i> {{Paramètres généraux}}</legend>
+              <div class="form-group">
+                  <label class="col-sm-3 control-label">{{Nom}}</label>
+                  <div class="col-sm-7">
+                      <input type="text" class="eqLogicAttr form-control" data-l1key="id" style="display : none;"/>
+                      <input type="text" class="eqLogicAttr form-control" data-l1key="name" placeholder="{{Nom de l'équipement Vigilances Météo}}"/>
+                  </div>
+              </div>
+              <div class="form-group">
+                  <label class="col-sm-3 control-label" >{{Objet parent}}</label>
+                  <div class="col-sm-7">
+                      <select id="sel_object" class="eqLogicAttr form-control" data-l1key="object_id">
+                          <option value="">{{Aucun}}</option>
+                          <?php
+										$options = '';
+										foreach ((jeeObject::buildTree(null, false)) as $object) {
+											$options .= '<option value="' . $object->getId() . '">' . str_repeat('&nbsp;&nbsp;', $object->getConfiguration('parentNumber')) . $object->getName() . '</option>';
+                          }
+                          ?>
+                      </select>
+                  </div>
+              </div>
+              <div class="form-group">
+                  <label class="col-sm-3 control-label">{{Catégorie}}</label>
+                  <div class="col-sm-7">
+                      <?php
+                      foreach (jeedom::getConfiguration('eqLogic:category') as $key => $value) {
+                          echo '<label class="checkbox-inline">';
+                          echo '<input type="checkbox" class="eqLogicAttr" data-l1key="category" data-l2key="' . $key . '" />' . $value['name'];
+                          echo '</label>';
+                      }
+                      ?>
+                  </div>
+              </div>
+              <div class="form-group">
+                  <label class="col-sm-3 control-label">{{Options}}</label>
+                  <div class="col-sm-7">
+                      <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="isEnable" checked/>{{Activer}}</label>
+                      <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="isVisible" checked/>{{Visible}}</label>
+                  </div>
+              </div>
+
+							<legend><i class="fas fa-cogs"></i> {{Paramètres spécifiques}}</legend>
+              <div class="form-group">
+                  <label class="col-sm-3 control-label" >{{Type de Vigilance}}</label>
+                  <div class="col-sm-7">
+                      <select id="typeEq" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="type">
+                          <option value="vigilance">{{Vigilance Météo France}}</option>
+                          <option value="pluie1h">{{Pluie à 1h Météo France}}</option>
+                          <option value="crue">{{Vigicrues}}</option>
+                          <option value="maree">{{Marées}}</option>
+                          <option value="surf">{{Surf}}</option>
+                          <option value="plage">{{Météo des Plages}}</option>
+                          <option value="air">{{Qualité d'Air}}</option>
+                          <option value="pollen">{{Index Pollens}}</option>
+                          <option value="gdacs">{{Alertes Globales}}</option>
+                      </select>
+                  </div>
+              </div>
+
+              <div id="villeEq" class="form-group" style="display:none">
+                  <label class="col-sm-3 control-label" >{{Ville}}</label>
+                  <div class="col-sm-3">
+                      <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="villeNom" type="text" placeholder="{{Ville}}" id="mfVilleNom" disabled>
+                  </div>
+                  <div class="col-sm-3">
+                      <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="ville" type="text" placeholder="{{ID Ville}}" id="mfVilleId" disabled>
+                  </div>
+                  <div class="col-sm-3">
+                      <a class="btn btn-default" id='btnSearchCity'><i class="fas fa-search"></i> {{Trouver la ville}}</a>
+                  </div>
+              </div>
+
+              <div id="portEq" class="form-group" style="display:none">
+    <div class="form-group">
+                  <label class="col-sm-3 control-label">{{Port}}</label>
+                  <div class="col-sm-7">
+<?php
+          $harbors = vigilancemeteo::mareeListHarbors();
+          if($harbors !== null) {
+            echo "<select type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\">";
+            foreach($harbors as $harbor) {
+              echo "<option value=" . $harbor['id'];
+              if(!isset($harbor['latitude']) || !isset($harbor['longitude'])) {
+                echo " disabled";
+              }
+              echo ">" .$harbor['name'] ." " .(isset($harbor['CP'])?$harbor['CP']:'---') ."</option>\n";
+            }
+            echo "</select>";
+          }
+          else {
+            echo "<input type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\" placeholder=\"52 pour Saint-Malo voir le site maree.info\"/>";
+          }
+?>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="col-sm-3 control-label" ></label>
+      <div class="col-sm-7">
+        <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useTideTemplate" checked/>{{Utiliser la template du plugin}}</label>
+      </div>
+                  </div>
+              </div>
+
+              <div id="stationEq" class="form-group" style="display:none">
+    <div class="form-group">
+                  <label class="col-sm-3 control-label">{{Station}}</label>
+                  <div class="col-sm-7">
+                      <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="station" placeholder="Ex F700000103 pour Paris Austerlitz"/>
+                  </div>
+              </div>
+    <div class="form-group">
+      <label class="col-sm-3 control-label" ></label>
+      <div class="col-sm-7">
+        <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useFloodTemplate" checked/>{{Utiliser la template du plugin}}</label>
+      </div>
     </div>
   </div>
 
+              <div id="geolocEq" class="form-group" style="display:none">
+                  <label class="col-sm-3 control-label">{{Localisation à utiliser}}</label>
+                  <div class="col-sm-7">
+                      <select class="form-control eqLogicAttr configuration" id="geoloc" data-l1key="configuration" data-l2key="geoloc">
+                          <?php
+                          $none = 0;
+                          if (class_exists('geotravCmd')) {
+                              foreach (eqLogic::byType('geotrav') as $geoloc) {
+                                  if ($geoloc->getConfiguration('type') == 'location') {
+                                      $none = 1;
+                                      echo '<option value="' . $geoloc->getId() . '">' . $geoloc->getName() . '</option>';
+                                  }
+                              }
+                          } 
+                          if ((config::byKey('info::latitude') != '') && (config::byKey('info::longitude') != '') && (config::byKey('info::postalCode') != '') && (config::byKey('info::stateCode') != '')) {
+                              echo '<option value="jeedom">Configuration Jeedom</option>';
+                              $none = 1;
+                          }
+                          if ($none == 0) {
+                              echo '<option value="">Pas de localisation disponible</option>';
+                          }
+                          ?>
+                      </select>
+                  </div>
+              </div>
 
-    <div class="col-lg-10 col-md-9 col-sm-8 eqLogic" style="border-left: solid 1px #EEE; padding-left: 25px;display: none;">
-        <a class="btn btn-success eqLogicAction pull-right" data-action="save"><i class="fas fa-check-circle"></i> {{Sauvegarder}}</a>
-        <a class="btn btn-danger eqLogicAction pull-right" data-action="remove"><i class="fas fa-minus-circle"></i> {{Supprimer}}</a>
-        <a class="btn btn-default eqLogicAction pull-right" data-action="configure"><i class="fas fa-cogs"></i> {{Configuration avancée}}</a>
-        <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fas fa-arrow-circle-left"></i></a></li>
-            <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
-            <li role="presentation"><a href="#commandtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fas fa-list-alt"></i> {{Commandes}}</a></li>
-        </ul>
-        <div class="tab-content" style="height:calc(100% - 50px);overflow:auto;overflow-x: hidden;">
-            <div role="tabpanel" class="tab-pane active" id="eqlogictab">
-                <br/>
-                <form class="form-horizontal">
-                    <fieldset>
-                        <div class="form-group">
-                            <label class="col-sm-3 control-label">{{Nom}}</label>
-                            <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr form-control" data-l1key="id" style="display : none;" />
-                                <input type="text" class="eqLogicAttr form-control" data-l1key="name" placeholder="{{Nom de l'équipement Vigilances Météo}}"/>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-sm-3 control-label" >{{Objet parent}}</label>
-                            <div class="col-sm-3">
-                                <select class="form-control eqLogicAttr" data-l1key="object_id">
-                                    <option value="">{{Aucun}}</option>
-                                    <?php
-                                    foreach (jeeObject::all() as $object) {
-                                        echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
-                                    }
-                                    ?>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-sm-3 control-label">{{Catégorie}}</label>
-                            <div class="col-sm-8">
-                                <?php
-                                foreach (jeedom::getConfiguration('eqLogic:category') as $key => $value) {
-                                    echo '<label class="checkbox-inline">';
-                                    echo '<input type="checkbox" class="eqLogicAttr" data-l1key="category" data-l2key="' . $key . '" />' . $value['name'];
-                                    echo '</label>';
-                                }
-                                ?>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-sm-3 control-label"></label>
-                            <div class="col-sm-8">
-                                <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="isEnable" checked/>{{Activer}}</label>
-                                <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="isVisible" checked/>{{Visible}}</label>
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <label class="col-sm-3 control-label" >{{Type de Vigilance}}</label>
-                            <div class="col-sm-3">
-                                <select id="typeEq" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="type">
-                                    <option value="vigilance">{{Vigilance Météo France}}</option>
-                                    <option value="pluie1h">{{Pluie à 1h Météo France}}</option>
-                                    <option value="crue">{{Vigicrues}}</option>
-                                    <option value="maree">{{Marées}}</option>
-                                    <option value="surf">{{Surf}}</option>
-                                    <option value="plage">{{Météo des Plages}}</option>
-                                    <option value="air">{{Qualité d'Air}}</option>
-                                    <option value="pollen">{{Index Pollens}}</option>
-                                    <option value="gdacs">{{Alertes Globales}}</option>
-                                </select>
-                            </div>
-                        </div>
-
-                        <div id="villeEq" class="form-group" style="display:none">
-                            <label class="col-sm-3 control-label" >{{Ville}}</label>
-                            <div class="col-sm-3">
-                                <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="villeNom" type="text" placeholder="{{Ville}}" id="mfVilleNom" disabled>
-                            </div>
-                            <div class="col-sm-3">
-                                <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="ville" type="text" placeholder="{{ID Ville}}" id="mfVilleId" disabled>
-                            </div>
-                            <div class="col-sm-3">
-                                <a class="btn btn-default" id='btnSearchCity'><i class="fas fa-search"></i> {{Trouver la ville}}</a>
-                            </div>
-                        </div>
-
-                        <div id="portEq" class="form-group" style="display:none">
-              <div class="form-group">
-                            <label class="col-sm-3 control-label">{{Port}}</label>
-                            <div class="col-sm-3">
-<?php
-                    $harbors = vigilancemeteo::mareeListHarbors();
-                    if($harbors !== null) {
-                      echo "<select type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\">";
-                      foreach($harbors as $harbor) {
-                        echo "<option value=" . $harbor['id'];
-                        if(!isset($harbor['latitude']) || !isset($harbor['longitude'])) {
-                          echo " disabled";
-                        }
-                        echo ">" .$harbor['name'] ." " .(isset($harbor['CP'])?$harbor['CP']:'---') ."</option>\n";
-                      }
-                      echo "</select>";
-                    }
-                    else {
-                      echo "<input type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\" placeholder=\"52 pour Saint-Malo voir le site maree.info\"/>";
-                    }
-?>
+              <div id="pollenEq" class="form-group" style="display:none">
+                <label class="col-sm-3 control-label"></label>
+                <div class="col-sm-7">
+                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="displayNullPollen" checked/>{{Afficher les pollens niveau 0}}</label>
                 </div>
               </div>
-              <div class="form-group">
-                <label class="col-sm-3 control-label" ></label>
-                <div class="col-sm-3">
-                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useTideTemplate" checked/>{{Utiliser la template du plugin}}</label>
-                </div>
-                            </div>
-                        </div>
 
-                        <div id="stationEq" class="form-group" style="display:none">
-              <div class="form-group">
-                            <label class="col-sm-3 control-label">{{Station}}</label>
-                            <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="station" placeholder="Ex F700000103 pour Paris Austerlitz"/>
-                            </div>
-                        </div>
-              <div class="form-group">
-                <label class="col-sm-3 control-label" ></label>
-                <div class="col-sm-3">
-                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useFloodTemplate" checked/>{{Utiliser la template du plugin}}</label>
-                </div>
+              <div id="breezeEq" class="form-group" style="display:none">
+                  <label class="col-sm-3 control-label">{{Clef}} <a href='http://aqicn.org/api/'>AQICN</a></label>
+                  <div class="col-sm-7">
+                      <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="aqicn" placeholder="exemple 122"/>
+                  </div>
               </div>
-            </div>
 
-                        <div id="geolocEq" class="form-group" style="display:none">
-                            <label class="col-sm-3 control-label">{{Localisation à utiliser}}</label>
-                            <div class="col-sm-3">
-                                <select class="form-control eqLogicAttr configuration" id="geoloc" data-l1key="configuration" data-l2key="geoloc">
-                                    <?php
-                                    $none = 0;
-                                    if (class_exists('geotravCmd')) {
-                                        foreach (eqLogic::byType('geotrav') as $geoloc) {
-                                            if ($geoloc->getConfiguration('type') == 'location') {
-                                                $none = 1;
-                                                echo '<option value="' . $geoloc->getId() . '">' . $geoloc->getName() . '</option>';
-                                            }
-                                        }
-                                    } 
-                                    if ((config::byKey('info::latitude') != '') && (config::byKey('info::longitude') != '') && (config::byKey('info::postalCode') != '') && (config::byKey('info::stateCode') != '')) {
-                                        echo '<option value="jeedom">Configuration Jeedom</option>';
-                                        $none = 1;
-                                    }
-                                    if ($none == 0) {
-                                        echo '<option value="">Pas de localisation disponible</option>';
-                                    }
-                                    ?>
-                                </select>
-                            </div>
-                        </div>
+              <div id="surfEq" class="form-group" style="display:none">
+                  <label class="col-sm-3 control-label">{{ID Spot}}</label>
+                  <div class="col-sm-7">
+                      <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="surf" placeholder="exemple 1"/>
+                  </div>
+              </div>
 
-                        <div id="pollenEq" class="form-group" style="display:none">
-                          <label class="col-sm-3 control-label"></label>
-                          <div class="col-sm-8">
-                            <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="displayNullPollen" checked/>{{Afficher les pollens niveau 0}}</label>
-                          </div>
-                        </div>
+              <div id="mswEq" class="form-group" style="display:none">
+                  <label class="col-sm-3 control-label">{{Clef}} <a href='http://magicseaweed.com/developer/api'>Magicseaweed</a></label>
+                  <div class="col-sm-7">
+                      <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="magicseaweed" placeholder="clef API"/>
+                  </div>
+              </div>
+      </div>
+          </fieldset>
+        </form>
+            <hr>
+			</div><!-- /.tabpanel #eqlogictab-->
 
-                        <div id="breezeEq" class="form-group" style="display:none">
-                            <label class="col-sm-3 control-label">{{Clef}} <a href='http://aqicn.org/api/'>AQICN</a></label>
-                            <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="aqicn" placeholder="exemple 122"/>
-                            </div>
-                        </div>
-
-                        <div id="surfEq" class="form-group" style="display:none">
-                            <label class="col-sm-3 control-label">{{ID Spot}}</label>
-                            <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="surf" placeholder="exemple 1"/>
-                            </div>
-                        </div>
-
-                        <div id="mswEq" class="form-group" style="display:none">
-                            <label class="col-sm-3 control-label">{{Clef}} <a href='http://magicseaweed.com/developer/api'>Magicseaweed</a></label>
-                            <div class="col-sm-3">
-                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="magicseaweed" placeholder="clef API"/>
-                            </div>
-                        </div>
-                    </fieldset>
-                </form>
-            </div>
+			<!-- Onglet des commandes de l'équipement -->
             <div role="tabpanel" class="tab-pane" id="commandtab">
-                <br/>
+                <br/><br/>
+				<div class="table-responsive">
                 <table id="table_cmd" class="table table-bordered table-condensed">
                     <thead>
                         <tr>
@@ -259,9 +275,12 @@ $eqLogics = eqLogic::byType('vigilancemeteo');
                     </tbody>
                 </table>
             </div>
-        </div>
-    </div>
-</div>
+			</div><!-- /.tabpanel #commandtab-->
+		</div><!-- /.tab-content -->
+	</div><!-- /.eqLogic -->
+</div><!-- /.row row-overflow -->
 
-<?php include_file('desktop', 'vigilancemeteo', 'js', 'vigilancemeteo'); ?>
-<?php include_file('core', 'plugin.template', 'js'); ?>
+<!-- Inclusion du fichier javascript du plugin (dossier, nom_du_fichier, extension_du_fichier, id_du_plugin) -->
+<?php include_file('desktop', 'vigilancemeteo', 'js', 'vigilancemeteo');?>
+<!-- Inclusion du fichier javascript du core - NE PAS MODIFIER NI SUPPRIMER -->
+<?php include_file('core', 'plugin.template', 'js');?>

--- a/desktop/php/vigilancemeteo.php
+++ b/desktop/php/vigilancemeteo.php
@@ -143,50 +143,18 @@ $eqLogics = eqLogic::byType('vigilancemeteo');
                         </div>
 
                         <div id="portEq" class="form-group" style="display:none">
-              <div class="form-group">
                             <label class="col-sm-3 control-label">{{Port}}</label>
                             <div class="col-sm-3">
-<?php
-                    $harbors = vigilancemeteo::mareeListHarbors();
-                    if($harbors !== null) {
-                      echo "<select type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\">";
-                      foreach($harbors as $harbor) {
-                        echo "<option value=" . $harbor['id'];
-                        if(!isset($harbor['latitude']) || !isset($harbor['longitude'])) {
-                          echo " disabled";
-                        }
-                        echo ">" .$harbor['name'] ." " .(isset($harbor['CP'])?$harbor['CP']:'---') ."</option>\n";
-                      }
-                      echo "</select>";
-                    }
-                    else {
-                      echo "<input type=\"text\" class=\"eqLogicAttr configuration form-control\" data-l1key=\"configuration\" data-l2key=\"port\" placeholder=\"52 pour Saint-Malo voir le site maree.info\"/>";
-                    }
-?>
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="col-sm-3 control-label" ></label>
-                <div class="col-sm-3">
-                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useTideTemplate" checked/>{{Utiliser la template du plugin}}</label>
-                </div>
+                                <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="port" placeholder="exemple 122"/>
                             </div>
                         </div>
 
                         <div id="stationEq" class="form-group" style="display:none">
-              <div class="form-group">
                             <label class="col-sm-3 control-label">{{Station}}</label>
                             <div class="col-sm-3">
                                 <input type="text" class="eqLogicAttr configuration form-control" data-l1key="configuration" data-l2key="station" placeholder="exemple 122"/>
                             </div>
                         </div>
-              <div class="form-group">
-                <label class="col-sm-3 control-label" ></label>
-                <div class="col-sm-3">
-                  <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="useFloodTemplate" checked/>{{Utiliser la template du plugin}}</label>
-                </div>
-              </div>
-            </div>
 
                         <div id="geolocEq" class="form-group" style="display:none">
                             <label class="col-sm-3 control-label">{{Localisation à utiliser}}</label>

--- a/plugin_info/pre_install.php
+++ b/plugin_info/pre_install.php
@@ -18,6 +18,7 @@
 
 require_once __DIR__ . '/../../../core/php/core.inc.php';
 
+/*
 function vigilancemeteo_pre_update() {
   $srcDir	 = __DIR__ . '/../core/template/dashboard/';
   $files = array('air','crue','gdacs','maree','plage','pollen','previsionpluie','surf','uvi','vigilancemeteo');
@@ -27,4 +28,5 @@ function vigilancemeteo_pre_update() {
     }
   }
 }
+*/
 ?>


### PR DESCRIPTION
- Changement de maree.info pour meteoconsult. (idem HA)
Le plugin génére une requête tous les 10 jours et recupère les marées pour 14 jours. soit ~50 étales 
La tache cron est utilisée pour récupérer les données quand il ne reste que 10 étales et pour mettre à jour le dashboard au changement de marées.
- nouvelle template avec les marées précedente et suivante, le nom du port et les marées suivantes dans une table.
- Les commandes Basse mer, Haute mer et Indicateur de marée sont encore calculées pour compatibilité.
- J'ai essayé de conserver les numéros de port de maree.info comme identifiant. La correspondance se fait via le fichier core/config/PortsMareeInfo.json La liste des ports apparait dans la configuration de l'équipement. Certains ne sont pas sélectionnables dans la liste, je n'ai pas trouvé leur correspondance. Il faut les latitude et longitude et le nom du port pour qu'ils soient utilisables. A ajouter dans le fichier.
Je en garantis pas que tous les ports fonctionne aprés cette corespondance. J'ai corrigé la récupération du nom du port. Elle se fait dans les données fournies par le site en meme temps que les marées.

- Corrections pour v4 ( recherche des équipements, objets parents en arborescence ) Toutes les vigilances sont concernées par cette modif.
- Sur la vigilance crue et marees, posiibilité de ne pas utiliser la template du plugin. Ex: pour avoir le widget rain du core pour la hauteur d'eau dans la vigilance crue.
