### PR TITLE
Update PortsMareeInfo.json

### DIFF
--- a/core/config/PortsMareeInfo.json
+++ b/core/config/PortsMareeInfo.json
@@ -251,7 +251,7 @@
     },
     { "id":"96", "name":"Hennebont"
     },
-    { "id":"110", "name":"Penerf"
+    { "id":110, "name":"Penerf", "latitude":47.5137, "longitude":-2.62346, "pays": "France", "CP": "56750"
     },
     { "id":"111", "name":"Tréhiguier"
     },


### PR DESCRIPTION
Ajout des infos du port de Penerf.
Comparé avec https://meteofrance.com/meteo-marine/penerf/570346 :  C'est ok.
J'ai également les infos du port de Tréhiguier pas loin de chez moi mais quand je compare, je n'ai pas les mêmes horaires...